### PR TITLE
feat: rebuild against new tpm2-tss version

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+tpm2-abrmd (3.0.0-1.1deepin2) unstable; urgency=medium
+
+  * Rebuild against new tpm2-tss version
+
+ -- lichenggang <lichenggang@deepin.org>  Tue, 28 Apr 2026 17:41:00 +0800
+
 tpm2-abrmd (3.0.0-1.1deepin1) unstable; urgency=low
 
   * add support for TCM devices


### PR DESCRIPTION
## Summary
Rebuild tpm2-abrmd against the updated tpm2-tss package.

## Changes
- Updated debian/changelog: bumped version from 3.0.0-1.1deepin1 to 3.0.0-1.1deepin2
- Added rebuild entry for new tpm2-tss version

## Test plan
- [ ] Verify tpm2-abrmd builds with new tpm2-tss
- [ ] Check tpm2-abrmd functionality after rebuild